### PR TITLE
feat?: Add `sse` and `http` embedding

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,0 +1,129 @@
+import { json, text } from 'node:stream/consumers'
+
+import cds from '@sap/cds'
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
+
+import { createServer } from './index.js'
+
+const transports = {}
+transports.create = async function () {
+  // New initialization request
+  const transport = new StreamableHTTPServerTransport({
+    // REVISIT: potentially use cds.context middleware
+    sessionIdGenerator: () => { return cds.utils.uuid() },
+    onsessioninitialized: (sessionId) => {
+      console.log('started session:', sessionId)
+      transports[sessionId] = transport
+    },
+    // enableDnsRebindingProtection: true,
+    // allowedHosts: ['127.0.0.1'],
+  })
+
+  // Clean up transport when closed
+  transport.onclose = () => {
+    if (transport.sessionId) {
+      delete transports[transport.sessionId]
+    }
+  }
+
+  await createServer().connect(transport)
+
+  return transport
+}
+
+cds.on('bootstrap', async app => {
+
+  app.post('/mcp', async (req, res) => {
+    const body = await text(req)
+    if (body) req.body = JSON.parse(body)
+
+    // Check for existing session ID
+    const sessionId = req.headers['mcp-session-id']
+    let transport
+
+    if (sessionId && transports[sessionId]) {
+      // Reuse existing transport
+      console.log('handling session:', sessionId)
+      transport = transports[sessionId]
+    } else if (!sessionId && isInitializeRequest(req.body)) {
+      transport = await transports.create(req, res)
+    } else {
+      // Invalid request
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: No valid session ID provided',
+        },
+        id: null,
+      })
+      return
+    }
+
+    // Handle the request
+    await transport.handleRequest(req, res, req.body)
+  })
+
+  // Reusable handler for GET and DELETE requests
+  const handleSessionRequest = async (req, res) => {
+    const sessionId = req.headers['mcp-session-id']
+    if (!sessionId || !transports[sessionId]) {
+      return res.writeHead(405).end(JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Method not allowed."
+        },
+        id: null
+      }))
+    }
+    const transport = transports[sessionId]
+    await transport.handleRequest(req, res)
+  }
+
+  // Handle GET requests for server-to-client notifications via SSE
+  app.get('/mcp', handleSessionRequest)
+
+  // Handle DELETE requests for session termination
+  app.delete('/mcp', handleSessionRequest)
+
+  app.get("/mcp/sse", async (req, res) => {
+    let transport
+    const server = await createServer()
+
+    if (req?.query?.sessionId) {
+      const sessionId = (req?.query?.sessionId)
+      transport = transports[sessionId]
+      console.log("Client Reconnecting? This shouldn't happen when client has a sessionId, GET /sse should not be called again.", transport.sessionId)
+    } else {
+      // Create and store transport for new session
+      transport = new SSEServerTransport("/message", res)
+      transports[transport.sessionId] = transport
+
+      // Connect server to transport
+      await server.connect(transport)
+      console.log("Client Connected: ", transport.sessionId)
+
+      // Handle close of connection
+      server.onclose = async () => {
+        console.log("Client Disconnected: ", transport.sessionId)
+        delete transports[transport.sessionId]
+        await cleanup()
+      }
+    }
+  })
+
+  app.post("/message", async (req, res) => {
+    const sessionId = (req?.query?.sessionId)
+    const transport = transports[sessionId]
+    if (transport) {
+      console.log("Client Message from", sessionId)
+      await transport.handlePostMessage(req, res)
+    } else {
+      console.log(`No transport found for sessionId ${sessionId}`)
+    }
+  })
+})

--- a/index.js
+++ b/index.js
@@ -9,72 +9,76 @@ const PROJECT_PATH = { projectPath: z.string().describe('Root path of the projec
 
 import cds from '@sap/cds'
 
-const server = new McpServer({
-  name: 'cds-mcp',
-  version: '0.1.0',
-  capabilities: {
-    resources: {},
-    roots: {}
-  }
-})
+export async function createServer() {
+  const server = new McpServer({
+    name: 'cds-mcp',
+    version: '0.1.0',
+    capabilities: {
+      resources: {},
+      roots: {}
+    }
+  })
 
-const models = new Map()
-async function getModel(path) {
-  if (models.has(path)) return models.get(path)
-  cds.root = path
-  try {
-    const model = cds.linked(await cds.load('*', { docs: true, locations: true }))
-    models.set(path, model)
-    return model
-  } catch (err) {
-    console.error(err)
-  }
-}
-
-server.tool(
-  'find_cds_definition',
-  {
-    ...PROJECT_PATH,
-    name: z.string().describe('Name of the definition (fuzzy search)'),
-    n: z.number().default(1).describe('Number of results')
-  },
-  async ({ projectPath, name, n }) => {
-    const model = await getModel(projectPath)
-    const names = Object.keys(model.definitions)
-    const scores = fuzzyTopN(name, names, n)
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(scores.map(s => Object.assign({ name: s.item }, model.definitions[s.item])))
-        }
-      ]
+  const models = new Map()
+  async function getModel(path) {
+    if (models.has(path)) return models.get(path)
+    cds.root = path
+    try {
+      const model = cds.linked(await cds.load('*', { docs: true, locations: true }))
+      models.set(path, model)
+      return model
+    } catch (err) {
+      console.error(err)
     }
   }
-)
 
-server.tool(
-  'list_cds_definition_names',
-  { ...PROJECT_PATH, kind: z.string().optional().describe('Kind of the definition (service, entity, action, ...)') },
-  async ({ projectPath, kind }) => {
-    const model = await getModel(projectPath)
-    const definitions = kind
-      ? Object.entries(model.definitions)
+  server.tool(
+    'find_cds_definition',
+    {
+      ...PROJECT_PATH,
+      name: z.string().describe('Name of the definition (fuzzy search)'),
+      n: z.number().default(1).describe('Number of results')
+    },
+    async ({ projectPath, name, n }) => {
+      const model = await getModel(projectPath)
+      const names = Object.keys(model.definitions)
+      const scores = fuzzyTopN(name, names, n)
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(scores.map(s => Object.assign({ name: s.item }, model.definitions[s.item])))
+          }
+        ]
+      }
+    }
+  )
+
+  server.tool(
+    'list_cds_definition_names',
+    { ...PROJECT_PATH, kind: z.string().optional().describe('Kind of the definition (service, entity, action, ...)') },
+    async ({ projectPath, kind }) => {
+      const model = await getModel(projectPath)
+      const definitions = kind
+        ? Object.entries(model.definitions)
           .filter(([_k, v]) => v.kind === kind)
           .map(([k]) => k)
-      : Object.keys(model.definitions)
-    return {
-      content: [{ type: 'text', text: JSON.stringify(definitions) }]
+        : Object.keys(model.definitions)
+      return {
+        content: [{ type: 'text', text: JSON.stringify(definitions) }]
+      }
     }
-  }
-)
+  )
 
-async function main() {
-  const transport = new StdioServerTransport()
-  await server.connect(transport)
+  return server
 }
 
-main().catch(error => {
-  console.error('Fatal error in main():', error)
-  process.exit(1)
-})
+if (process.argv[1] === import.meta.filename) {
+  const transport = new StdioServerTransport()
+  createServer().then(async server => server.connect(transport)
+    .catch(error => {
+      console.error('Fatal error in main():', error)
+      process.exit(1)
+    })
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "cds-mcp",
-  "version": "1.0.0",
+  "name": "@cap-js/cds-mcp",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cds-mcp",
-      "version": "1.0.0",
+      "name": "@cap-js/cds-mcp",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.8.0",
+        "@modelcontextprotocol/sdk": "^1.15.1",
         "@sap/cds": "^8.9.1"
       },
       "bin": {
-        "cds-mcp": "dist/index.js"
+        "cds-mcp": "index.js"
       },
       "devDependencies": {
         "@cap-js/cds-types": "^0.10.0"
@@ -42,18 +42,20 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
-      "integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.1.tgz",
+      "integrity": "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==",
       "license": "MIT",
       "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^4.1.0",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
@@ -337,12 +339,12 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-8.9.1.tgz",
-      "integrity": "sha512-+KoY7Bw1Gc3vwK4X3CFCV+IAQO4QT0HRsaW/qgETeOGqjzbuf6KvUqlkDuPE5msdXwfz/EFDB9Vx9jTyTw581Q==",
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-8.9.4.tgz",
+      "integrity": "sha512-pgEx855xxtrBkYEtvWOLHqBCvFePbV4ERCpssDn7K4G8WipoXMcOPCkAYq1aP+OVpjz2WMb3p7QSwu4qHwWFKw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@sap/cds-compiler": ">=5.1",
+        "@sap/cds-compiler": "^5",
         "@sap/cds-fiori": "^1",
         "@sap/cds-foss": "^5.0.0"
       },
@@ -369,9 +371,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-5.9.2.tgz",
-      "integrity": "sha512-YpRUD3L0Ylg7KNoDqdCmsH1n6vt22Uvyvtc7Maj0wPl7haqeDOax2ouOAtqgJaYJfu83pcyx04sWLK6oH+Lh0w==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-5.9.6.tgz",
+      "integrity": "sha512-/lOp0DGCK/Tr9HmRLSIpBZcxss5S8x6K/wMOxs3KvZdB8UnBoqW2H0BZJIMJ7JCg+OEy7nzd4J6e/ZC9rRs4Zg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "antlr4": "4.9.3"
@@ -540,6 +542,22 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/antlr4": {
@@ -902,6 +920,18 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1087,6 +1117,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1247,9 +1283,9 @@
       "peer": true
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -1266,6 +1302,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -1600,6 +1645,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1650,15 +1704,15 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cds-mcp": "./index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "@sap/cds": "^8.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
It works fine with `@modelcontextprotocol/inspector`, but wasn't able to have an actual agent call any of the `tools`. It succeeds to list the `tools`, but is unable to call any of them.