### PR TITLE
added mcp.json instructions for usage in GitHub Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Example for VS Code extension [Cline](https://marketplace.visualstudio.com/items
 }
 ```
 
+Example for VS Code global [mcp.json](https://code.visualstudio.com/docs/copilot/customization/mcp-servers):
+> Note: GitHub Copilot uses the `mcp.json` file as source for it's Agent mode.
+```json
+{
+	"servers": {
+		"cds-mcp": {
+			"command": "cds-mcp",
+			"args": [],
+			"env": {},
+			"type": "stdio"
+		},
+	"inputs": []
+}
+```
+
 See [VS Code Marketplace](https://marketplace.visualstudio.com/search?term=tag%3Aagent&target=VSCode&category=All%20categories&sortBy=Relevance) for more agent extensions.
 
 ### Usage in opencode


### PR DESCRIPTION
This PR adds a minor change to the readme.md file to add instructions for adding the MCP server to the global mcp.json file.