### PR TITLE
feat: CLI argument management with --offline and --download-embeddings

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { join, dirname } from 'node:path'
 import run, { runTool } from './lib/run.js'
 import { downloadEmbeddings } from './lib/searchMarkdownDocs.js'
+import { forceDownloadModel } from './lib/calculateEmbeddings.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -45,6 +46,7 @@ if (values['download-embeddings']) {
     process.exit(1)
   }
   const result = await downloadEmbeddings()
+  await forceDownloadModel()
   console.log(JSON.stringify(result))
 } else if (values.help) {
   console.log(helpText)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const helpText = `Usage: cds-mcp [options] [tool] [args...]
 Options:
   -h, --help                 Show this help message
   -v, --version              Show version number
-      --download-embeddings  Download latest documentation embeddings
+      --download             Download latest embeddings and model files
       --offline              Skip downloading of embeddings updates
 
 Environment variables:
@@ -33,6 +33,7 @@ try {
       help: { type: 'boolean', short: 'h' },
       version: { type: 'boolean', short: 'v' },
       'download-embeddings': { type: 'boolean' },
+      download: { type: 'boolean' },
       offline: { type: 'boolean' }
     },
     allowPositionals: true,
@@ -43,9 +44,9 @@ try {
   process.exit(1)
 }
 
-if (values['download-embeddings']) {
+if (values.download || values['download-embeddings']) {
   if (Object.values(values).filter(Boolean).length > 1 || positionals.length > 0) {
-    console.error('--download-embeddings must be the only argument')
+    console.error('--download must be the only argument')
     process.exit(1)
   }
   const result = await downloadEmbeddings()

--- a/index.js
+++ b/index.js
@@ -1,12 +1,56 @@
 #!/usr/bin/env node
 
+import { parseArgs } from 'node:util'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
 import run, { runTool } from './lib/run.js'
+import { downloadEmbeddings } from './lib/searchMarkdownDocs.js'
 
-const args = process.argv.slice(2)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
-if (args.length > 0 && !args[0].startsWith('-')) {
-  const toolName = args[0]
-  const toolArgs = args.slice(1)
+/* eslint-disable no-console */
+const helpText = `Usage: cds-mcp [options] [tool] [args...]
+
+Options:
+  -h, --help                 Show this help message
+  -v, --version              Show version number
+      --download-embeddings  Download latest documentation embeddings
+
+Tools:
+  search_model <projectPath> [name] [kind] [topN] [namesOnly]
+  search_docs <query> [maxResults]`
+
+let values, positionals
+try {
+  ;({ values, positionals } = parseArgs({
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      version: { type: 'boolean', short: 'v' },
+      'download-embeddings': { type: 'boolean' }
+    },
+    allowPositionals: true,
+    strict: true
+  }))
+} catch {
+  console.error(helpText)
+  process.exit(1)
+}
+
+if (values['download-embeddings']) {
+  if (Object.values(values).filter(Boolean).length > 1 || positionals.length > 0) {
+    console.error('--download-embeddings must be the only argument')
+    process.exit(1)
+  }
+  const result = await downloadEmbeddings()
+  console.log(JSON.stringify(result))
+} else if (values.help) {
+  console.log(helpText)
+} else if (values.version) {
+  const pkg = JSON.parse(await readFile(join(__dirname, 'package.json'), 'utf-8'))
+  console.log(pkg.version)
+} else if (positionals.length > 0) {
+  const [toolName, ...toolArgs] = positionals
   runTool(toolName, ...toolArgs)
 } else {
   run()

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ Options:
   -h, --help                 Show this help message
   -v, --version              Show version number
       --download-embeddings  Download latest documentation embeddings
+      --offline              Skip downloading of embeddings updates
 
 Tools:
   search_model <projectPath> [name] [kind] [topN] [namesOnly]
@@ -27,7 +28,8 @@ try {
     options: {
       help: { type: 'boolean', short: 'h' },
       version: { type: 'boolean', short: 'v' },
-      'download-embeddings': { type: 'boolean' }
+      'download-embeddings': { type: 'boolean' },
+      offline: { type: 'boolean' }
     },
     allowPositionals: true,
     strict: true

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ Options:
       --download-embeddings  Download latest documentation embeddings
       --offline              Skip downloading of embeddings updates
 
+Environment variables:
+  CDS_MCP_OFFLINE=true       Same as --offline
+
 Tools:
   search_model <projectPath> [name] [kind] [topN] [namesOnly]
   search_docs <query> [maxResults]`

--- a/lib/calculateEmbeddings.js
+++ b/lib/calculateEmbeddings.js
@@ -7,7 +7,7 @@ import * as ort from 'onnxruntime-web'
 ort.env.debug = false
 ort.env.logLevel = 'error'
 
-const offline = process.argv.includes('--offline')
+const offline = process.argv.includes('--offline') || process.env.CDS_MCP_OFFLINE === 'true'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/lib/calculateEmbeddings.js
+++ b/lib/calculateEmbeddings.js
@@ -7,6 +7,8 @@ import * as ort from 'onnxruntime-web'
 ort.env.debug = false
 ort.env.logLevel = 'error'
 
+const offline = process.argv.includes('--offline')
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2'
@@ -44,6 +46,8 @@ async function downloadFile(url, outputPath) {
 }
 
 async function downloadModelIfNeeded() {
+  if (offline) return
+
   try {
     await fs.access(MODEL_DIR)
   } catch {
@@ -59,8 +63,22 @@ async function downloadModelIfNeeded() {
   }
 }
 
+export async function forceDownloadModel() {
+  for (const file of FILES) {
+    const filePath = path.join(MODEL_DIR, path.basename(file))
+    await fs.unlink(filePath).catch(() => {})
+  }
+  await fs.mkdir(MODEL_DIR, { recursive: true })
+  for (const file of FILES) {
+    const filePath = path.join(MODEL_DIR, path.basename(file))
+    const url = `https://huggingface.co/${MODEL_NAME}/resolve/main/${file}`
+    await downloadFile(url, filePath)
+  }
+}
+
 async function forceRedownloadModel() {
-  // Reset session and vocab to force reinitialization
+  if (offline) throw new Error('Model corrupted and --offline prevents re-download')
+
   session = null
   vocab = null
 
@@ -107,7 +125,8 @@ async function initializeModelAndVocab() {
 
   try {
     await loadModelAndVocab()
-  } catch {
+  } catch (error) {
+    if (offline) throw error
     // Model or tokenizer is corrupted, force re-download
     await forceRedownloadModel()
 
@@ -447,7 +466,8 @@ export default async function calculateEmbeddings(text) {
   try {
     const pooledEmbedding = await processChunkedEmbeddings(chunks, session)
     return normalizeEmbedding(pooledEmbedding)
-  } catch {
+  } catch (error) {
+    if (offline) throw error
     // If inference fails, it might be due to model corruption
     // Try to recover by re-downloading and reinitializing
 

--- a/lib/searchMarkdownDocs.js
+++ b/lib/searchMarkdownDocs.js
@@ -120,10 +120,10 @@ export async function downloadEmbeddings() {
   }
 }
 
-let downloadPromise = downloadEmbeddings()
+let downloadPromise = process.argv.includes('--offline') ? null : downloadEmbeddings()
 
 export default async function searchMarkdownDocs(query, maxResults = 10) {
-  await downloadPromise
+  if (downloadPromise) await downloadPromise
 
   async function searchWithRetry(retryCount = 0) {
     try {
@@ -132,6 +132,7 @@ export default async function searchMarkdownDocs(query, maxResults = 10) {
       return results.map(r => r.content).join('\n---\n')
     } catch (error) {
       if (error.code === 'EMBEDDINGS_CORRUPTED' && retryCount < 2) {
+        if (process.argv.includes('--offline')) throw error
         downloadPromise = downloadEmbeddings()
         await downloadPromise
         return searchWithRetry(retryCount + 1)

--- a/lib/searchMarkdownDocs.js
+++ b/lib/searchMarkdownDocs.js
@@ -22,7 +22,15 @@ async function checkFilesExist(jsonPath, binPath) {
   return jsonExists && binExists
 }
 
-async function downloadEmbeddings() {
+async function readStoredEtag() {
+  try {
+    return await fs.readFile(etagPath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+export async function downloadEmbeddings() {
   try {
     await fs.mkdir(embeddingsDir, { recursive: true })
     const jsonPath = path.join(embeddingsDir, 'code-chunks.json')
@@ -30,12 +38,7 @@ async function downloadEmbeddings() {
 
     const filesExist = await checkFilesExist(jsonPath, binPath)
 
-    let storedEtag = null
-    try {
-      storedEtag = await fs.readFile(etagPath, 'utf-8')
-    } catch {
-      // No stored ETag found, first download
-    }
+    const storedEtag = await readStoredEtag()
 
     const headers = {}
     if (storedEtag) {
@@ -45,12 +48,12 @@ async function downloadEmbeddings() {
     const jsonResponse = await fetch('https://cap.cloud.sap/resources/embeddings/code-chunks.json', { headers })
 
     if (jsonResponse.status === 304) {
-      return
+      return { etag: storedEtag, updated: false }
     }
 
     if (!jsonResponse.ok) {
       if (filesExist) {
-        return
+        return { etag: storedEtag, updated: false }
       }
       throw new Error(`Failed to download JSON: ${jsonResponse.status} ${jsonResponse.statusText}`)
     }
@@ -58,7 +61,7 @@ async function downloadEmbeddings() {
     const newEtag = jsonResponse.headers.get('etag')
 
     if (storedEtag && newEtag && storedEtag.trim() === newEtag.trim()) {
-      return
+      return { etag: storedEtag, updated: false }
     }
 
     const jsonData = await jsonResponse.arrayBuffer()
@@ -67,7 +70,7 @@ async function downloadEmbeddings() {
 
     if (!binResponse.ok) {
       if (filesExist) {
-        return
+        return { etag: storedEtag, updated: false }
       }
       throw new Error(`Failed to download BIN: ${binResponse.status} ${binResponse.statusText}`)
     }
@@ -96,10 +99,12 @@ async function downloadEmbeddings() {
       }
 
       if (filesExist) {
-        return
+        return { etag: storedEtag, updated: false }
       }
       throw writeError
     }
+
+    return { etag: newEtag, updated: true }
   } catch (error) {
     const jsonPath = path.join(embeddingsDir, 'code-chunks.json')
     const binPath = path.join(embeddingsDir, 'code-chunks.bin')
@@ -107,7 +112,8 @@ async function downloadEmbeddings() {
     const filesExist = await checkFilesExist(jsonPath, binPath)
 
     if (filesExist) {
-      // Using existing files due to download failure
+      const storedEtag = await readStoredEtag()
+      return { etag: storedEtag, updated: false }
     } else {
       throw error
     }

--- a/lib/searchMarkdownDocs.js
+++ b/lib/searchMarkdownDocs.js
@@ -120,7 +120,9 @@ export async function downloadEmbeddings() {
   }
 }
 
-let downloadPromise = process.argv.includes('--offline') ? null : downloadEmbeddings()
+const offline = process.argv.includes('--offline') || process.env.CDS_MCP_OFFLINE === 'true'
+
+let downloadPromise = offline ? null : downloadEmbeddings()
 
 export default async function searchMarkdownDocs(query, maxResults = 10) {
   if (downloadPromise) await downloadPromise
@@ -132,7 +134,7 @@ export default async function searchMarkdownDocs(query, maxResults = 10) {
       return results.map(r => r.content).join('\n---\n')
     } catch (error) {
       if (error.code === 'EMBEDDINGS_CORRUPTED' && retryCount < 2) {
-        if (process.argv.includes('--offline')) throw error
+        if (offline) throw error
         downloadPromise = downloadEmbeddings()
         await downloadPromise
         return searchWithRetry(retryCount + 1)

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -122,6 +122,16 @@ test.describe('CLI usage', () => {
     assert(result.stderr.includes('must be the only argument'), 'Should show error message')
   })
 
+  test('CDS_MCP_OFFLINE=true search_docs works without downloading', async () => {
+    const result = await runCliCommand(['search_docs', 'select statement'], {
+      env: { ...process.env, CDS_MCP_OFFLINE: 'true' }
+    })
+
+    assert.equal(result.code, 0, 'Command should exit with code 0')
+    assert(result.stdout.length > 0, 'Should produce output')
+    assert(result.stdout.includes('---'), 'Output should contain document separators')
+  })
+
   test('no arguments starts MCP server mode', async () => {
     const child = spawn('node', [cdsMcpPath], {
       stdio: 'pipe'

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -91,15 +91,15 @@ test.describe('CLI usage', () => {
     assert(result.stderr.includes('Usage: cds-mcp'), 'Should show usage in stderr')
   })
 
-  test('--download-embeddings rejects extra arguments', async () => {
-    const result = await runCliCommand(['--download-embeddings', '--help'])
+  test('--download rejects extra arguments', async () => {
+    const result = await runCliCommand(['--download', '--help'])
 
     assert.equal(result.code, 1, 'Command should exit with code 1')
     assert(result.stderr.includes('must be the only argument'), 'Should show error message')
   })
 
-  test('--download-embeddings returns etag info', async () => {
-    const result = await runCliCommand(['--download-embeddings'])
+  test('--download returns etag info', async () => {
+    const result = await runCliCommand(['--download'])
 
     assert.equal(result.code, 0, 'Command should exit with code 0')
     const output = JSON.parse(result.stdout)
@@ -115,8 +115,8 @@ test.describe('CLI usage', () => {
     assert(result.stdout.includes('---'), 'Output should contain document separators')
   })
 
-  test('--offline is incompatible with --download-embeddings', async () => {
-    const result = await runCliCommand(['--offline', '--download-embeddings'])
+  test('--offline is incompatible with --download', async () => {
+    const result = await runCliCommand(['--offline', '--download'])
 
     assert.equal(result.code, 1, 'Command should exit with code 1')
     assert(result.stderr.includes('must be the only argument'), 'Should show error message')

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -68,6 +68,45 @@ test.describe('CLI usage', () => {
     assert(result.stderr.includes('Available tools:'), 'Should list available tools')
   })
 
+  test('--help shows usage information', async () => {
+    const result = await runCliCommand(['--help'])
+
+    assert.equal(result.code, 0, 'Command should exit with code 0')
+    assert(result.stdout.includes('Usage: cds-mcp'), 'Should show usage line')
+    assert(result.stdout.includes('--help'), 'Should list --help option')
+    assert(result.stdout.includes('search_model'), 'Should list search_model tool')
+  })
+
+  test('--version shows version number', async () => {
+    const result = await runCliCommand(['--version'])
+
+    assert.equal(result.code, 0, 'Command should exit with code 0')
+    assert(/^\d+\.\d+\.\d+/.test(result.stdout.trim()), 'Should print a semver version')
+  })
+
+  test('unknown flag shows help and exits with error', async () => {
+    const result = await runCliCommand(['--foo'])
+
+    assert.equal(result.code, 1, 'Command should exit with code 1')
+    assert(result.stderr.includes('Usage: cds-mcp'), 'Should show usage in stderr')
+  })
+
+  test('--download-embeddings rejects extra arguments', async () => {
+    const result = await runCliCommand(['--download-embeddings', '--help'])
+
+    assert.equal(result.code, 1, 'Command should exit with code 1')
+    assert(result.stderr.includes('must be the only argument'), 'Should show error message')
+  })
+
+  test('--download-embeddings returns etag info', async () => {
+    const result = await runCliCommand(['--download-embeddings'])
+
+    assert.equal(result.code, 0, 'Command should exit with code 0')
+    const output = JSON.parse(result.stdout)
+    assert(typeof output.etag === 'string', 'Should return an etag string')
+    assert(typeof output.updated === 'boolean', 'Should return an updated boolean')
+  })
+
   test('no arguments starts MCP server mode', async () => {
     const child = spawn('node', [cdsMcpPath], {
       stdio: 'pipe'

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -107,6 +107,21 @@ test.describe('CLI usage', () => {
     assert(typeof output.updated === 'boolean', 'Should return an updated boolean')
   })
 
+  test('--offline search_docs works without downloading', async () => {
+    const result = await runCliCommand(['--offline', 'search_docs', 'select statement'])
+
+    assert.equal(result.code, 0, 'Command should exit with code 0')
+    assert(result.stdout.length > 0, 'Should produce output')
+    assert(result.stdout.includes('---'), 'Output should contain document separators')
+  })
+
+  test('--offline is incompatible with --download-embeddings', async () => {
+    const result = await runCliCommand(['--offline', '--download-embeddings'])
+
+    assert.equal(result.code, 1, 'Command should exit with code 1')
+    assert(result.stderr.includes('must be the only argument'), 'Should show error message')
+  })
+
   test('no arguments starts MCP server mode', async () => {
     const child = spawn('node', [cdsMcpPath], {
       stdio: 'pipe'

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -36,6 +36,11 @@ function runCliCommand(args, options = {}) {
   })
 }
 
+const noFetchEnv = {
+  ...process.env,
+  NODE_OPTIONS: '--import "data:text/javascript,globalThis.fetch = () => { throw new Error(\'fetch disabled in offline mode\') }"'
+}
+
 test.describe('CLI usage', () => {
   test('search_model subcommand works', async () => {
     const result = await runCliCommand(['search_model', sampleProjectPath, 'Books', 'entity'])
@@ -108,7 +113,9 @@ test.describe('CLI usage', () => {
   })
 
   test('--offline search_docs works without downloading', async () => {
-    const result = await runCliCommand(['--offline', 'search_docs', 'select statement'])
+    const result = await runCliCommand(['--offline', 'search_docs', 'select statement'], {
+      env: noFetchEnv
+    })
 
     assert.equal(result.code, 0, 'Command should exit with code 0')
     assert(result.stdout.length > 0, 'Should produce output')
@@ -124,7 +131,7 @@ test.describe('CLI usage', () => {
 
   test('CDS_MCP_OFFLINE=true search_docs works without downloading', async () => {
     const result = await runCliCommand(['search_docs', 'select statement'], {
-      env: { ...process.env, CDS_MCP_OFFLINE: 'true' }
+      env: { ...noFetchEnv, CDS_MCP_OFFLINE: 'true' }
     })
 
     assert.equal(result.code, 0, 'Command should exit with code 0')


### PR DESCRIPTION
## Summary

- Replace ad-hoc `if/else` argument handling in `index.js` with Node.js built-in `util.parseArgs` for proper CLI management
- Add `--help`, `--version`, `--download-embeddings`, and `--offline` flags
- Unknown flags now print usage to stderr and exit with code 1
- `--download-embeddings` fetches latest doc embeddings (with ETag check) and ONNX model, returns `{ etag, updated }` as JSON — must be the only argument
- `--offline` skips all network calls (embeddings + model downloads at startup and on corruption recovery), using local files only
- Offline mode can be set CDS_MCP_OFFLINE=true env variable — useful for MCP client configs (e.g. VS Code mcp.json) where you can set env but not CLI flags.

## Test plan

- [x] `--help` prints usage and exits 0
- [x] `--version` prints semver and exits 0
- [x] Unknown flag (`--foo`) prints usage to stderr, exits 1
- [x] `--download-embeddings` returns etag info as JSON
- [x] `--download-embeddings` rejects extra arguments
- [x] `--offline search_docs` works without downloading
- [x] `--offline` + `--download-embeddings` is rejected
- [x] Existing tool subcommands (`search_model`, `search_docs`) still work
- [x] No-args still starts MCP server
- [x] All embeddings tests pass