### PR TITLE
chore: dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,13 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 
 version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: 'weekly'
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,31 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
-    versioning-strategy: increase-if-necessary
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 3
     groups:
-      production-dependencies:
+      prod-dependencies:
         dependency-type: 'production'
-      development-dependencies:
+        update-types:
+          - 'minor'
+          - 'patch'
+      dev-dependencies:
         dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
# Add Dependabot Cooldown and GitHub Actions Ecosystem

### Chore

🔧 Updated the Dependabot configuration to introduce a cooldown period for dependency updates and extend coverage to GitHub Actions, while also cleaning up and standardizing the existing configuration.

### Changes

* `.github/dependabot.yml`:
  - Added a `cooldown` setting with `default-days: 3` for both the `npm` and `github-actions` ecosystems to reduce the frequency of update PRs.
  - Added a new `github-actions` package ecosystem entry with weekly scheduling and the same cooldown configuration.
  - Renamed dependency groups from `production-dependencies`/`development-dependencies` to `prod-dependencies`/`dev-dependencies`.
  - Added explicit `update-types` (`minor`, `patch`) for both dependency groups.
  - Updated the documentation URL comment and removed the `versioning-strategy` field.
  - General formatting and style cleanup (added quotes and inline comments for clarity).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `40ee2039-f001-4dad-83e1-2d1dcf5f15a7`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
