### PR TITLE
chore(dependabot): use versioning-strategy increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: increase
     schedule:
       interval: 'weekly'
     cooldown:


### PR DESCRIPTION
# Update Dependabot Versioning Strategy to `increase`

### Chore

🔧 Updated the Dependabot configuration to use the `increase` versioning strategy instead of `increase-if-necessary` for npm package updates.

### Changes

* `.github/dependabot.yml`: Changed `versioning-strategy` from `increase-if-necessary` to `increase` for the npm package ecosystem. This ensures Dependabot always increases version numbers in `package.json` when updating dependencies, rather than only doing so when necessary.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `ddc89791-8f2a-454e-b87c-0c5494950fab`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
