### PR TITLE
chore(ci): rm node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
# Remove Node.js 20 from CI Matrix

### Chore

🔧 Removed Node.js 20.x from the CI test matrix, keeping only Node.js 22.x and 24.x as supported versions.

### Changes

* `.github/workflows/ci.yml`: Updated the `test` job strategy matrix to drop `20.x`, retaining `[22.x, 24.x]` as the tested Node.js versions.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- File Content Strategy: Full file content
- Correlation ID: `df48b172-7848-4556-b991-29f347c166b1`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
