### PR TITLE
chore: update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.x
       - run: npm ci
@@ -28,9 +28,9 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
# Update CI: Pin Action Versions, Drop Node 20.x, and Add `.npmrc` Security Setting

### Chore

🔧 Updated the CI pipeline with pinned action versions, a narrowed Node.js test matrix, and a new `.npmrc` security configuration.

### Changes

* `.github/workflows/ci.yml`: Pinned `actions/checkout` to `v6.0.2` and `actions/setup-node` to `v6.4.0` across all workflow steps for more reproducible builds. Removed Node.js `20.x` from the test matrix, narrowing CI test runs to Node.js `22.x` and `24.x` only.
* `.github/workflows/release.yml`: Pinned `actions/checkout` to `v6.0.2` and `actions/setup-node` to `v6.4.0` to match the CI workflow updates.
* `.npmrc`: Added a new npm configuration file with `ignore-scripts=true`, preventing automatic execution of lifecycle scripts (e.g., `preinstall`, `postinstall`) during `npm install`. This reduces the risk of unintended or malicious scripts running in CI environments.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Correlation ID: `7dbfa782-0a0a-4f8d-b5ff-dd857e71f6b1`
- Event Trigger: `pull_request.edited`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
