### PR TITLE
chore: NPM_CONFIG_IGNORE_SCRIPTS instead of .npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -33,5 +36,5 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i
+      - run: npm ci
       - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ permissions:
 on:
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: run tests
         run: |
           npm i -g @sap/cds-dk
-          npm i
+          npm ci
           npm run lint
           npm run test
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true


### PR DESCRIPTION
# Replace `.npmrc` with `NPM_CONFIG_IGNORE_SCRIPTS` Environment Variable in CI/CD Workflows

### Chore

🔧 Replaced the `.npmrc` file approach for ignoring npm scripts with the `NPM_CONFIG_IGNORE_SCRIPTS=true` environment variable set directly in the CI/CD workflow files.

### Changes

* `.github/workflows/ci.yml`: Added a top-level `env` block setting `NPM_CONFIG_IGNORE_SCRIPTS: true`. Also fixed the test job to use `npm ci` instead of `npm i` for more reliable, reproducible installs.
* `.github/workflows/release.yml`: Added a top-level `env` block setting `NPM_CONFIG_IGNORE_SCRIPTS: true`.
* `.npmrc`: Removed, as its functionality is now handled via the environment variable in the workflow files.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `171e50db-114c-420a-b777-2613af5e3ba4`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
