### PR TITLE
chore: pin GitHub Actions via SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
       - run: npm ci
@@ -31,9 +31,9 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -30,7 +30,7 @@ jobs:
 
       - name: get version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
       - name: check versions
         run: |
           version_in_server_json=$(jq -r '.packages[0].version' server.json)
@@ -50,12 +50,12 @@ jobs:
 
       - name: parse changelog
         id: parse-changelog
-        uses: schwma/parse-changelog-action@v1.2.0
+        uses: schwma/parse-changelog-action@1c2b2005ccf594cc3a45d33c10af4ab924d3a1c5 # v1.2.0
         with:
           version: '${{ steps.package-version.outputs.current-version }}'
 
       - name: create a GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           tag: 'v${{ steps.package-version.outputs.current-version }}'
           body: '${{ steps.parse-changelog.outputs.body }}'


### PR DESCRIPTION
Pin all workflow actions to full commit SHAs with version comments, matching the pattern from [cap-js/advanced-event-mesh#76](https://github.com/cap-js/advanced-event-mesh/pull/76).

Pinning by immutable SHA prevents a moving tag (e.g. a compromised or re-pointed `v1`) from silently changing the action our CI/release runs. The trailing `# vX.Y.Z` comment keeps the human-readable version and lets Dependabot continue to bump them.

## Pinned actions

| Action | SHA | Version |
|---|---|---|
| actions/checkout | `de0fac2` | v6.0.2 |
| actions/setup-node | `48b55a0` | v6.4.0 |
| martinbeentjes/npm-get-version-action | `3cf2730` | v1.3.1 |
| schwma/parse-changelog-action | `1c2b200` | v1.2.0 |
| ncipollo/release-action | `339a818` | v1 |

Note: `ncipollo/release-action` was previously on the floating major tag `v1`; it's now pinned to that tag's current commit.