### PR TITLE
docs: add Claude Code setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The server helps AI models answer questions such as:
 - [Requirements](#requirements)
 - [Setup](#setup)
   - [Usage in VS Code](#usage-in-vs-code)
+  - [Usage in Claude Code](#usage-in-claude-code)
   - [Usage in opencode](#usage-in-opencode)
   - [CLI Usage](#cli-usage)
 - [Available Tools](#available-tools)
@@ -77,6 +78,14 @@ Example for VS Code global [mcp.json](https://code.visualstudio.com/docs/copilot
 ```
 
 See [VS Code Marketplace](https://marketplace.visualstudio.com/search?term=tag%3Aagent&target=VSCode&category=All%20categories&sortBy=Relevance) for more agent extensions.
+
+### Usage in Claude Code
+
+Register the server with [Claude Code](https://claude.com/claude-code):
+
+```sh
+claude mcp add cds-mcp -- npx -y @cap-js/mcp-server
+```
 
 ### Usage in opencode
 


### PR DESCRIPTION
# Add Claude Code Setup Instructions to README

### Documentation

📚 Added setup instructions for using the MCP server with **Claude Code**, complementing the existing VS Code and opencode setup guides.

### Changes

* `README.md`:
  - Added `Usage in Claude Code` entry to the Table of Contents.
  - Added a new `### Usage in Claude Code` section with a shell command to register the MCP server using Claude Code's CLI (`claude mcp add cds-mcp -- npx -y @cap-js/mcp-server`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.9`

- Correlation ID: `51454a90-8cb9-11f1-9fe9-47918c02f141`
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
