### PR TITLE
Pplx embed context

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ Options:
 
 Environment variables:
   CDS_MCP_OFFLINE=true       Same as --offline
+  CDS_MCP_MODEL=<org/name>   HuggingFace model to use for embeddings
+                             (default: perplexity-ai/pplx-embed-context-v1-0.6b)
 
 Tools:
   search_model <projectPath> [name] [kind] [topN] [namesOnly]

--- a/lib/calculateEmbeddings.js
+++ b/lib/calculateEmbeddings.js
@@ -11,10 +11,15 @@ const offline = process.argv.includes('--offline') || process.env.CDS_MCP_OFFLIN
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2'
-const MODEL_DIR = path.resolve(__dirname, '..', 'models')
+const MODEL_NAME = process.env.CDS_MCP_MODEL || 'perplexity-ai/pplx-embed-context-v1-0.6b'
+// Each model gets its own subdir so switching models doesn't reuse stale files.
+const MODEL_DIR = path.resolve(__dirname, '..', 'models', MODEL_NAME.replace(/\//g, '--'))
 
 const FILES = ['onnx/model.onnx', 'tokenizer.json', 'tokenizer_config.json']
+
+// pplx-embed splits ONNX weights into external _data files that must sit alongside
+// model.onnx for the runtime to resolve them.
+const EXTRA_FILES = ['onnx/model.onnx_data', 'onnx/model.onnx_data_1']
 
 async function saveFile(buffer, outputPath) {
   await fs.writeFile(outputPath, Buffer.from(buffer))
@@ -61,10 +66,20 @@ async function downloadModelIfNeeded() {
       await downloadFile(url, filePath)
     }
   }
+  // Optional external-data files (pplx-embed splits ONNX weights into sidecars).
+  // Silently skip 404s for models that don't have them.
+  for (const file of EXTRA_FILES) {
+    const filePath = path.join(MODEL_DIR, path.basename(file))
+    if (!(await fileExists(filePath))) {
+      const url = `https://huggingface.co/${MODEL_NAME}/resolve/main/${file}`
+      const res = await fetch(url)
+      if (res.ok) await saveFile(await res.arrayBuffer(), filePath)
+    }
+  }
 }
 
 export async function forceDownloadModel() {
-  for (const file of FILES) {
+  for (const file of [...FILES, ...EXTRA_FILES]) {
     const filePath = path.join(MODEL_DIR, path.basename(file))
     await fs.unlink(filePath).catch(() => {})
   }
@@ -73,6 +88,12 @@ export async function forceDownloadModel() {
     const filePath = path.join(MODEL_DIR, path.basename(file))
     const url = `https://huggingface.co/${MODEL_NAME}/resolve/main/${file}`
     await downloadFile(url, filePath)
+  }
+  for (const file of EXTRA_FILES) {
+    const filePath = path.join(MODEL_DIR, path.basename(file))
+    const url = `https://huggingface.co/${MODEL_NAME}/resolve/main/${file}`
+    const res = await fetch(url)
+    if (res.ok) await saveFile(await res.arrayBuffer(), filePath)
   }
 }
 
@@ -83,7 +104,7 @@ async function forceRedownloadModel() {
   vocab = null
 
   // Delete all model files to force re-download
-  for (const file of FILES) {
+  for (const file of [...FILES, ...EXTRA_FILES]) {
     const filePath = path.join(MODEL_DIR, path.basename(file))
     if (await fileExists(filePath)) {
       await fs.unlink(filePath).catch(() => {})
@@ -99,9 +120,17 @@ async function initializeModelAndVocab() {
   const vocabPath = path.join(MODEL_DIR, 'tokenizer.json')
 
   const loadModelAndVocab = async () => {
-    // Load model as buffer for onnxruntime-web
-    const modelBuffer = await fs.readFile(modelPath)
-    session = await ort.InferenceSession.create(modelBuffer)
+    // Models with external weight files (model.onnx_data) need onnxruntime-node
+    // loaded by path — onnxruntime-web can't resolve sidecar files in Node.js.
+    const hasExternalData = await fileExists(path.join(MODEL_DIR, 'model.onnx_data'))
+      || await fileExists(path.join(MODEL_DIR, 'model.onnx_data_1'))
+    if (hasExternalData) {
+      const ortNode = await import('onnxruntime-node')
+      session = await ortNode.InferenceSession.create(modelPath)
+    } else {
+      const modelBuffer = await fs.readFile(modelPath)
+      session = await ort.InferenceSession.create(modelBuffer)
+    }
 
     // Try to parse tokenizer JSON
     const tokenizerJson = JSON.parse(await fs.readFile(vocabPath, 'utf-8'))

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sap/cds": ">=9",
+    "onnxruntime-node": "^1.24.3",
     "onnxruntime-web": "^1.24.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# Add Perplexity Embed Context Model Support with Retrieval Eval Harness

### New Features

✨ This PR introduces two major additions:

1. **Switch the default embedding model** from `Xenova/all-MiniLM-L6-v2` to `perplexity-ai/pplx-embed-context-v1-0.6b`, with full support for models that use external ONNX weight sidecar files (`model.onnx_data`). The model is now configurable via `CDS_MCP_MODEL`.

2. **A complete deterministic RAG retrieval eval harness** (`evals/`) that scores the `search_docs` tool against a frozen human-authored golden set, computes standard IR metrics, and renders HTML/Markdown comparison dashboards.

### Changes

* `lib/calculateEmbeddings.js`: Changed default model to `perplexity-ai/pplx-embed-context-v1-0.6b` via `CDS_MCP_MODEL` env var. Each model now gets its own subdirectory under `models/`. Added support for downloading and loading ONNX external data sidecar files (`model.onnx_data`), using `onnxruntime-node` for models with external data files.

* `lib/embeddings.js`: Added a disk-backed embedding cache keyed by `(model, chunk-text SHA-256 hash)`, so re-runs only recompute embeddings for changed chunks. Added progress logging with elapsed time and ETA (configurable via `EMBEDDINGS_LOG_EVERY`; suppress with `=0`).

* `index.js`: Added `CDS_MCP_MODEL` to the help text.

* `evals/config.json`: Central configuration for the eval harness (K, gates, paths, output format).

* `evals/data/golden-set.json`: Frozen golden set of 10 CAP-domain questions with human-authored relevance labels.

* `evals/lib/metrics.js`: Pure-arithmetic implementations of Recall@K, Precision@K, MRR, Hit-Rate@K, and nDCG@K.

* `evals/lib/runner.js`: Core eval logic — builds reports, computes deltas vs. baseline, diagnoses regressions (chunking/embedding vs. ranking), validates the golden set.

* `evals/lib/cli.js`: Orchestration entry point (`run()` and `runAll()`), wires retriever, golden set, baseline, and store together.

* `evals/lib/compare.js`: Generates a self-contained HTML dashboard (line charts, leaderboard, per-question searchable table with lazy charts) or a Markdown report.

* `evals/lib/store.js`: Append-only JSONL result store with run capping and chronological sorting.

* `evals/lib/config.js`: Config loader with `EVAL_*` env overrides and programmatic override support.

* `evals/lib/ids.js`: Pure string parsing of `Source:` URLs from chunks for stable doc identity; fallback to `capire://generated/` slugs.

* `evals/lib/retriever.js`: Wraps `search_docs` and resolves returned chunk text to corpus-consistent doc IDs.

* `evals/docs/README.md` / `evals/docs/METRICS.md`: Full documentation for running the harness and understanding each metric.

* `evals/bin/eval.js` / `evals/bin/compare.js`: Thin CLI entry points for `npm run evals` and `npm run evals:compare`.

* `package.json`: Added `evals`, `evals:compare`, and `evals:test` npm scripts.

* `tests/embedding-cache.test.js` / `tests/embedding-progress.test.js`: Tests for the new embedding cache and progress logging.

* `evals/tests/unit/*.test.js`: Comprehensive unit tests for all eval harness components (metrics, runner, CLI, store, compare, config, IDs, retriever).

* `.gitignore`: Added `evals/runs/` to ignore transient eval output.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Correlation ID: `11c401d0-92ff-11f1-87b1-6502bb781a84`
</details>
