### PR TITLE
docs: add Codex setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The server helps AI models answer questions such as:
   - [Usage in VS Code](#usage-in-vs-code)
   - [Usage in Claude Code](#usage-in-claude-code)
   - [Usage in opencode](#usage-in-opencode)
+  - [Usage in Codex](#usage-in-codex)
   - [CLI Usage](#cli-usage)
 - [Available Tools](#available-tools)
   - [`search_model`](#search_model)
@@ -100,6 +101,13 @@ Example for [opencode](https://github.com/sst/opencode):
     }
   }
 }
+```
+
+### Usage in Codex
+
+Example for [OpenAI Codex](https://openai.com/codex):
+```sh
+codex mcp add cds-mcp -- npx -y @cap-js/mcp-server
 ```
 
 ### Rules

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The server helps AI models answer questions such as:
 - [Setup](#setup)
   - [Usage in VS Code](#usage-in-vs-code)
   - [Usage in Claude Code](#usage-in-claude-code)
-  - [Usage in opencode](#usage-in-opencode)
   - [Usage in Codex](#usage-in-codex)
+  - [Usage in opencode](#usage-in-opencode)
   - [CLI Usage](#cli-usage)
 - [Available Tools](#available-tools)
   - [`search_model`](#search_model)
@@ -88,6 +88,14 @@ Register the server with [Claude Code](https://claude.com/claude-code):
 claude mcp add cds-mcp -- npx -y @cap-js/mcp-server
 ```
 
+### Usage in Codex
+
+Register the server with [OpenAI Codex](https://openai.com/codex):
+
+```sh
+codex mcp add cds-mcp -- npx -y @cap-js/mcp-server
+```
+
 ### Usage in opencode
 
 Example for [opencode](https://github.com/sst/opencode):
@@ -101,13 +109,6 @@ Example for [opencode](https://github.com/sst/opencode):
     }
   }
 }
-```
-
-### Usage in Codex
-
-Example for [OpenAI Codex](https://openai.com/codex):
-```sh
-codex mcp add cds-mcp -- npx -y @cap-js/mcp-server
 ```
 
 ### Rules

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The server helps AI models answer questions such as:
 - [Setup](#setup)
   - [Usage in VS Code](#usage-in-vs-code)
   - [Usage in Claude Code](#usage-in-claude-code)
-  - [Usage in Codex](#usage-in-codex)
+  - [Usage in OpenAI Codex](#usage-in-openai-codex)
   - [Usage in opencode](#usage-in-opencode)
   - [CLI Usage](#cli-usage)
 - [Available Tools](#available-tools)
@@ -88,7 +88,7 @@ Register the server with [Claude Code](https://claude.com/claude-code):
 claude mcp add cds-mcp -- npx -y @cap-js/mcp-server
 ```
 
-### Usage in Codex
+### Usage in OpenAI Codex
 
 Register the server with [OpenAI Codex](https://openai.com/codex):
 


### PR DESCRIPTION
# docs: Add Codex Setup Instructions to README

### Documentation

📝 Added setup instructions for [OpenAI Codex](https://openai.com/codex) to the README, making it easier for users to integrate the CAP MCP server with the Codex CLI.

### Changes

* `README.md`:
  - Added `Usage in Codex` entry to the Table of Contents.
  - Added a new `### Usage in Codex` section with a shell command example (`codex mcp add cds-mcp -- npx -y @cap-js/mcp-server`) for configuring the MCP server in OpenAI Codex.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- Correlation ID: `94391ae0-94c3-11f1-8cfa-bbc6928fa10a`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
