### PR TITLE
feat(embeddings): surface optional metadata[] sidecar in loadChunks

### DIFF
--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -24,7 +24,7 @@ export async function loadChunks(id, dir = path.join(__dirname, '..', 'embedding
     } catch {
       _throwCorruptedError()
     }
-    const { dim, chunks, count } = meta
+    const { dim, chunks, count, metadata } = meta
 
     // Validate metadata structure
     if (!dim || !chunks || !Array.isArray(chunks)) {
@@ -33,6 +33,13 @@ export async function loadChunks(id, dir = path.join(__dirname, '..', 'embedding
 
     if (count !== undefined && count !== chunks.length) {
       _throwCorruptedError()
+    }
+
+    // Optional parallel metadata array — must be the same length if present.
+    if (metadata !== undefined) {
+      if (!Array.isArray(metadata) || metadata.length !== chunks.length) {
+        _throwCorruptedError()
+      }
     }
 
     // Read binary data
@@ -72,7 +79,9 @@ export async function loadChunks(id, dir = path.join(__dirname, '..', 'embedding
         }
       }
 
-      return { content: content, embeddings }
+      const entry = { content: content, embeddings }
+      if (metadata) entry.meta = metadata[i]
+      return entry
     })
 
     return result

--- a/tests/loadEmbeddings.test.js
+++ b/tests/loadEmbeddings.test.js
@@ -148,4 +148,55 @@ describe('loadEmbeddings tests', () => {
 
     await assert.rejects(loadChunks('code', TEST_EMBEDDINGSDIR), err => err.code === 'EMBEDDINGS_CORRUPTED')
   })
+
+  test('loads parallel metadata[] matched by index', async () => {
+    await fs.mkdir(TEST_EMBEDDINGSDIR, { recursive: true })
+
+    const meta = {
+      dim: 3,
+      count: 2,
+      chunks: ['Hello world', 'Test content'],
+      metadata: [
+        { source: 'a.md', breadcrumb: 'Root > A' },
+        { source: 'b.md' }
+      ]
+    }
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.json'), JSON.stringify(meta))
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.bin'), Buffer.from(new Float32Array([1, 2, 3, 4, 5, 6]).buffer))
+
+    const result = await loadChunks('code', TEST_EMBEDDINGSDIR)
+    assert.strictEqual(result[0].content, 'Hello world')
+    assert.deepStrictEqual(result[0].meta, { source: 'a.md', breadcrumb: 'Root > A' })
+    assert.strictEqual(result[1].content, 'Test content')
+    assert.deepStrictEqual(result[1].meta, { source: 'b.md' })
+  })
+
+  test('files without metadata[] load unchanged (backward compat)', async () => {
+    await fs.mkdir(TEST_EMBEDDINGSDIR, { recursive: true })
+
+    // Legacy on-disk shape: no `metadata` field at all.
+    const meta = { dim: 2, count: 2, chunks: ['a', 'b'] }
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.json'), JSON.stringify(meta))
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.bin'), Buffer.from(new Float32Array([1, 2, 3, 4]).buffer))
+
+    const result = await loadChunks('code', TEST_EMBEDDINGSDIR)
+    assert.strictEqual(result[0].content, 'a')
+    assert.strictEqual('meta' in result[0], false)
+    assert.strictEqual('meta' in result[1], false)
+  })
+
+  test('metadata[] with wrong length is treated as corrupted', async () => {
+    await fs.mkdir(TEST_EMBEDDINGSDIR, { recursive: true })
+
+    const meta = {
+      dim: 2,
+      count: 2,
+      chunks: ['a', 'b'],
+      metadata: [{ source: 'a.md' }] // length mismatch
+    }
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.json'), JSON.stringify(meta))
+    await fs.writeFile(path.join(TEST_EMBEDDINGSDIR, 'code.bin'), Buffer.from(new Float32Array([1, 2, 3, 4]).buffer))
+
+    await assert.rejects(loadChunks('code', TEST_EMBEDDINGSDIR), err => err.code === 'EMBEDDINGS_CORRUPTED')
+  })
 })


### PR DESCRIPTION
## Summary

- `loadChunks` reads an optional `metadata` array from the on-disk JSON meta file. When present it must have the same length as `chunks`, and each entry's value is exposed as `meta` on the corresponding returned object.
- When the JSON has no `metadata` field, the returned objects keep the exact pre-existing `{ content, embeddings }` shape — no `meta` key is added. Existing callers see no difference.
- Length mismatch between `chunks` and `metadata` is treated as corruption (same code path as other integrity checks).
- `createEmbeddings` is unchanged. Writers that want to attach metadata inject a `metadata` array into the emitted JSON out-of-band. Files produced without a `metadata` field are byte-identical to the previous layout.

Motivation: lets callers ship structured breadcrumb/source/etc. alongside chunks without changing the string that gets embedded — the vector stays clean while retrieval exposes navigational context.

## Diff scope

`lib/embeddings.js`: three hunks in `loadChunks` (destructure `metadata`, validate length, conditionally attach `meta` per entry). Nothing else touched.

## Test plan

- [x] `node --test tests/loadEmbeddings.test.js` — 12/12 pass, including new tests for parallel `metadata[]`, backward-compat legacy files (asserting `'meta' in entry === false`), and length-mismatch rejection.
- [x] `node --test tests/searchMarkdownDocs.test.js` — 5/5 pass, consumer unchanged.