### PR TITLE
feat(search): include per-chunk metadata in searchMarkdownDocs output

### DIFF
--- a/lib/searchMarkdownDocs.js
+++ b/lib/searchMarkdownDocs.js
@@ -124,6 +124,15 @@ const offline = process.argv.includes('--offline') || process.env.CDS_MCP_OFFLIN
 
 let downloadPromise = offline ? null : downloadEmbeddings()
 
+export function formatResult(r) {
+  if (!r.meta) return r.content
+  const header = Object.entries(r.meta)
+    .filter(([, v]) => v !== undefined && v !== null && v !== '')
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n')
+  return header ? `${header}\n\n${r.content}` : r.content
+}
+
 export default async function searchMarkdownDocs(query, maxResults = 10) {
   if (downloadPromise) await downloadPromise
 
@@ -131,7 +140,7 @@ export default async function searchMarkdownDocs(query, maxResults = 10) {
     try {
       const chunks = await loadChunks('code-chunks')
       const results = (await searchEmbeddings(query, chunks)).slice(0, maxResults)
-      return results.map(r => r.content).join('\n---\n')
+      return results.map(formatResult).join('\n---\n')
     } catch (error) {
       if (error.code === 'EMBEDDINGS_CORRUPTED' && retryCount < 2) {
         if (offline) throw error

--- a/tests/searchMarkdownDocs.test.js
+++ b/tests/searchMarkdownDocs.test.js
@@ -9,7 +9,47 @@ import fs from 'fs/promises'
 const embeddingsDir = path.join(__dirname, '..', 'embeddings')
 
 // Use dynamic import to ensure environment variable is set before module evaluation
-const searchMarkdownDocs = (await import('../lib/searchMarkdownDocs.js')).default
+const searchModule = await import('../lib/searchMarkdownDocs.js')
+const searchMarkdownDocs = searchModule.default
+const { formatResult } = searchModule
+
+describe('formatResult', () => {
+  test('returns content unchanged when meta is absent', () => {
+    assert.strictEqual(formatResult({ content: 'body' }), 'body')
+  })
+
+  test('backward compat: `meta` explicitly undefined behaves like missing key', () => {
+    assert.strictEqual(formatResult({ content: 'body', meta: undefined }), 'body')
+  })
+
+  test('backward compat: joined output for meta-less results is unchanged', () => {
+    // Simulates what searchMarkdownDocs does with pre-metadata files.
+    const results = [{ content: 'A' }, { content: 'B' }, { content: 'C' }]
+    const joined = results.map(formatResult).join('\n---\n')
+    assert.strictEqual(joined, 'A\n---\nB\n---\nC')
+  })
+
+  test('prepends meta as key: value lines separated by blank line', () => {
+    const out = formatResult({
+      content: 'body text',
+      meta: { source: 'a.md', breadcrumb: 'Root > A' }
+    })
+    assert.strictEqual(out, 'source: a.md\nbreadcrumb: Root > A\n\nbody text')
+  })
+
+  test('skips null/undefined/empty meta values', () => {
+    const out = formatResult({
+      content: 'body',
+      meta: { source: 'a.md', breadcrumb: null, tag: '', depth: undefined }
+    })
+    assert.strictEqual(out, 'source: a.md\n\nbody')
+  })
+
+  test('returns content only when all meta values are empty', () => {
+    assert.strictEqual(formatResult({ content: 'body', meta: {} }), 'body')
+    assert.strictEqual(formatResult({ content: 'body', meta: { x: null } }), 'body')
+  })
+})
 
 describe('searchMarkdownDocs integration tests', () => {
   test('should download and load embeddings from server', async () => {


### PR DESCRIPTION
When `loadChunks` surfaces `meta` on a result (via #142's optional `metadata[]` sidecar), `searchMarkdownDocs` prepends each non-empty meta field as a `key: value` line above the chunk content, separated by a blank line. Chunks without `meta` are formatted exactly as before.

Example header for `meta: { source: 'auth.md', breadcrumb: 'Docs > Auth' }`:

\`\`\`
source: auth.md
breadcrumb: Docs > Auth

<chunk body>
\`\`\`

No-op until published embeddings files carry `metadata[]`.

Tests: 9/9 pass, including 4 unit tests for `formatResult`.