### PR TITLE
feat(embeddings): accept separate embed and display chunks

### DIFF
--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -124,8 +124,16 @@ export async function searchEmbeddings(query, chunks) {
   return scoredChunks
 }
 
-// Only to be used in scripts, not in production
-export async function createEmbeddings(id, chunks, dir = path.join(__dirname, '..', 'embeddings')) {
+// Only to be used in scripts, not in production.
+// displayChunks (optional): separate strings to store in the JSON / return at retrieval.
+// When omitted, `chunks` is used for both.
+export async function createEmbeddings(id, chunks, displayChunks, dir) {
+  if (typeof displayChunks === 'string' || displayChunks === undefined) {
+    dir = displayChunks ?? path.join(__dirname, '..', 'embeddings')
+    displayChunks = null
+  }
+  dir ??= path.join(__dirname, '..', 'embeddings')
+
   const embeddings = []
 
   for (let i = 0; i < chunks.length; i++) {
@@ -133,7 +141,7 @@ export async function createEmbeddings(id, chunks, dir = path.join(__dirname, '.
     embeddings.push(embedding)
   }
 
-  await saveEmbeddings(id, chunks, embeddings, dir)
+  await saveEmbeddings(id, displayChunks ?? chunks, embeddings, dir)
 }
 
 async function saveEmbeddings(id, chunks, embeddings, dir) {

--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -128,8 +128,8 @@ export async function searchEmbeddings(query, chunks) {
 // displayChunks (optional): separate strings to store in the JSON / return at retrieval.
 // When omitted, `chunks` is used for both.
 export async function createEmbeddings(id, chunks, displayChunks, dir) {
-  if (typeof displayChunks === 'string' || displayChunks === undefined) {
-    dir = displayChunks ?? path.join(__dirname, '..', 'embeddings')
+  if (typeof displayChunks === 'string') {
+    dir = displayChunks
     displayChunks = null
   }
   dir ??= path.join(__dirname, '..', 'embeddings')


### PR DESCRIPTION
## Summary

- Adds optional `displayChunks` parameter to `createEmbeddings(id, chunks, displayChunks, dir)`
- Vectors are computed from `chunks`; `displayChunks` is stored in the JSON and returned at retrieval
- Enables callers to embed prose-only text while returning full content (including fences/tables) to the LLM

## Backwards compatibility

Fully backwards compatible. Existing callers using `createEmbeddings(id, chunks, dir)` are unchanged — the third argument is detected by type (`string` → treated as `dir`, `undefined` → default dir).