### PR TITLE
fix: mock docs resources endpoint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,5 +3,10 @@ export default [
   ...cds.recommended,
   {
     ignores: ['scripts/']
+  },
+  {
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+    }
   }
 ]

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -6,16 +6,15 @@ import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import fs from 'fs/promises'
 import os from 'os'
-import cds from '@sap/cds'
-import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
-import { buildTestBundle, TEST_COMMIT_ID } from './helpers/testBundle.js'
+import { DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
+import { buildTestBundle, getManifestEtagPath, TEST_COMMIT_ID } from './helpers/testBundle.js'
 
 const sampleProjectPath = join(dirname(fileURLToPath(import.meta.url)), 'sample')
 const cdsMcpPath = join(dirname(fileURLToPath(import.meta.url)), '../index.js')
 const mockFetchUrl = new URL('./helpers/mock-fetch.mjs', import.meta.url).href
 
 const testBundleDir = join(DEFAULT_EMBEDDINGS_DIR, TEST_COMMIT_ID)
-const manifestEtagPath = join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
+const manifestEtagPath = getManifestEtagPath()
 const bundlePath = join(os.tmpdir(), `cds-mcp-test-bundle-${process.pid}.bin`)
 let savedEtag = null
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,12 +1,23 @@
 // CLI test for cds-mcp command-line usage
 import assert from 'node:assert'
-import { test } from 'node:test'
+import { test, describe, before, after } from 'node:test'
 import { spawn } from 'node:child_process'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import fs from 'fs/promises'
+import os from 'os'
+import cds from '@sap/cds'
+import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
+import { buildTestBundle, TEST_COMMIT_ID } from './helpers/testBundle.js'
 
 const sampleProjectPath = join(dirname(fileURLToPath(import.meta.url)), 'sample')
 const cdsMcpPath = join(dirname(fileURLToPath(import.meta.url)), '../index.js')
+const mockFetchUrl = new URL('./helpers/mock-fetch.mjs', import.meta.url).href
+
+const testBundleDir = join(DEFAULT_EMBEDDINGS_DIR, TEST_COMMIT_ID)
+const manifestEtagPath = join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
+const bundlePath = join(os.tmpdir(), `cds-mcp-test-bundle-${process.pid}.bin`)
+let savedEtag = null
 
 function runCliCommand(args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -41,7 +52,36 @@ const noFetchEnv = {
   NODE_OPTIONS: '--import "data:text/javascript,globalThis.fetch = () => { throw new Error(\'fetch disabled in offline mode\') }"'
 }
 
-test.describe('CLI usage', () => {
+before(async () => {
+  // Save any real etag that exists before our subprocess tests overwrite it.
+  savedEtag = await fs.readFile(manifestEtagPath, 'utf-8').catch(() => null)
+
+  // Build real bundle, write to temp file for subprocess mock-fetch.mjs.
+  const frame = await buildTestBundle()
+  await fs.writeFile(bundlePath, frame)
+
+  // Pre-seed versioned embeddings dir for offline tests.
+  // resolveLocalVersion() last-resort scan will find this dir.
+  await fs.mkdir(testBundleDir, { recursive: true })
+  const metaLen = frame.readUInt32BE(0)
+  const metaBytes = frame.subarray(4, 4 + metaLen)
+  const binBytes = frame.subarray(4 + metaLen)
+  await fs.writeFile(join(testBundleDir, 'code-chunks.json'), metaBytes)
+  await fs.writeFile(join(testBundleDir, 'code-chunks.bin'), binBytes)
+})
+
+after(async () => {
+  await fs.rm(testBundleDir, { recursive: true, force: true }).catch(() => {})
+  await fs.unlink(bundlePath).catch(() => {})
+  if (savedEtag !== null) {
+    await fs.mkdir(dirname(manifestEtagPath), { recursive: true })
+    await fs.writeFile(manifestEtagPath, savedEtag)
+  } else {
+    await fs.rm(dirname(manifestEtagPath), { recursive: true, force: true }).catch(() => {})
+  }
+})
+
+describe('CLI usage', () => {
   test('search_model subcommand works', async () => {
     const result = await runCliCommand(['search_model', sampleProjectPath, 'Books', 'entity'])
 
@@ -54,14 +94,18 @@ test.describe('CLI usage', () => {
     assert(output[0].name, 'Result should have a name property')
   })
 
-  // TODO mock docs-resources endpoint for testing
-  test.skip('search_docs subcommand works', async () => {
-    const result = await runCliCommand(['search_docs', 'select statement'])
+  test('search_docs subcommand works', async () => {
+    const result = await runCliCommand(['search_docs', 'select statement'], {
+      env: {
+        ...process.env,
+        CDS_MCP_TEST_BUNDLE_PATH: bundlePath,
+        CDS_MCP_TEST_BUNDLE_VERSION: TEST_COMMIT_ID,
+        NODE_OPTIONS: `--import "${mockFetchUrl}"`
+      }
+    })
 
     assert.equal(result.code, 0, 'Command should exit with code 0')
     assert(result.stdout.length > 0, 'Should produce output')
-
-    // search_docs returns plain text, not JSON
     assert(typeof result.stdout === 'string', 'Output should be a string')
     assert(result.stdout.includes('---'), 'Output should contain document separators')
   })
@@ -104,18 +148,23 @@ test.describe('CLI usage', () => {
     assert(result.stderr.includes('must be the only argument'), 'Should show error message')
   })
 
-  // TODO mock docs-resources endpoint for testing
-  test.skip('--download returns etag info', async () => {
-    const result = await runCliCommand(['--download'])
+  test('--download returns commitId info', async () => {
+    const result = await runCliCommand(['--download'], {
+      env: {
+        ...process.env,
+        CDS_MCP_TEST_BUNDLE_PATH: bundlePath,
+        CDS_MCP_TEST_BUNDLE_VERSION: TEST_COMMIT_ID,
+        NODE_OPTIONS: `--import "${mockFetchUrl}"`
+      }
+    })
 
     assert.equal(result.code, 0, 'Command should exit with code 0')
     const output = JSON.parse(result.stdout)
-    assert(typeof output.etag === 'string', 'Should return an etag string')
+    assert(typeof output.commitId === 'string', 'Should return a commitId string')
     assert(typeof output.updated === 'boolean', 'Should return an updated boolean')
   })
 
-  // TODO mock docs-resources endpoint for testing
-  test.skip('--offline search_docs works without downloading', async () => {
+  test('--offline search_docs works without downloading', async () => {
     const result = await runCliCommand(['--offline', 'search_docs', 'select statement'], {
       env: noFetchEnv
     })
@@ -132,8 +181,7 @@ test.describe('CLI usage', () => {
     assert(result.stderr.includes('must be the only argument'), 'Should show error message')
   })
 
-  // TODO mock docs-resources endpoint for testing
-  test.skip('CDS_MCP_OFFLINE=true search_docs works without downloading', async () => {
+  test('CDS_MCP_OFFLINE=true search_docs works without downloading', async () => {
     const result = await runCliCommand(['search_docs', 'select statement'], {
       env: { ...noFetchEnv, CDS_MCP_OFFLINE: 'true' }
     })

--- a/tests/helpers/mock-fetch.mjs
+++ b/tests/helpers/mock-fetch.mjs
@@ -1,0 +1,16 @@
+// Subprocess fetch mock — loaded via NODE_OPTIONS=--import "file://..."
+// Reads bundle from CDS_MCP_TEST_BUNDLE_PATH, serves it for any fetch call.
+import { readFileSync } from 'node:fs'
+
+const frame = readFileSync(process.env.CDS_MCP_TEST_BUNDLE_PATH)
+const commitId = process.env.CDS_MCP_TEST_BUNDLE_VERSION ?? '__test_bundle__'
+
+globalThis.fetch = async (_url, _init) =>
+  new Response(frame, {
+    status: 200,
+    headers: {
+      etag: `W/"${commitId}"`,
+      'x-embeddings-version': commitId,
+      'content-type': 'application/octet-stream'
+    }
+  })

--- a/tests/helpers/testBundle.js
+++ b/tests/helpers/testBundle.js
@@ -1,0 +1,40 @@
+import calculateEmbeddings from '../../lib/calculateEmbeddings.js'
+
+export const TEST_COMMIT_ID = '__test_bundle__'
+
+// Small CAP-relevant chunks covering assertions in integration tests:
+// - 'cds init' for query 'how to create a new cap project'
+// - 'enterprise-messaging' for query 'event mesh config'
+const TEST_CHUNKS = [
+  'To create a new CAP project, run: cds init my-project. The cds init command scaffolds a minimal project.',
+  'Use cds add hana to add HANA support. First run cds init to bootstrap the project structure.',
+  'Enterprise messaging in CAP uses enterprise-messaging as the service binding kind in package.json under cds.requires.',
+  'SAP Event Mesh (enterprise-messaging) enables async messaging between microservices in CAP applications.',
+  'Define CDS entities: entity Books { key ID: Integer; title: String; author: Association to Authors; }',
+  'Expose entities via services: service CatalogService { entity Books as projection on my.Books; }',
+  'CQL SELECT statement syntax: SELECT from Books where title = :title order by title asc',
+]
+
+export async function buildTestBundle() {
+  const vecs = await Promise.all(TEST_CHUNKS.map(c => calculateEmbeddings(c)))
+  const dim = vecs[0].length
+  const flat = new Float32Array(TEST_CHUNKS.length * dim)
+  for (let i = 0; i < vecs.length; i++) flat.set(vecs[i], i * dim)
+  const meta = { dim, count: TEST_CHUNKS.length, chunks: TEST_CHUNKS }
+  const metaBuf = Buffer.from(JSON.stringify(meta))
+  const header = Buffer.alloc(4)
+  header.writeUInt32BE(metaBuf.length, 0)
+  return Buffer.concat([header, metaBuf, Buffer.from(flat.buffer)])
+}
+
+export function makeFetchStub(frame, commitId = TEST_COMMIT_ID) {
+  return async (_url, _init) =>
+    new Response(frame, {
+      status: 200,
+      headers: {
+        etag: `W/"${commitId}"`,
+        'x-embeddings-version': commitId,
+        'content-type': 'application/octet-stream'
+      }
+    })
+}

--- a/tests/helpers/testBundle.js
+++ b/tests/helpers/testBundle.js
@@ -1,4 +1,6 @@
-import calculateEmbeddings from '../../lib/calculateEmbeddings.js'
+import { createRequire } from 'node:module'
+import path from 'path'
+import calculateEmbeddings, { DEFAULT_DIR, UNKNOWN_CDS_VERSION } from '../../lib/calculateEmbeddings.js'
 
 export const TEST_COMMIT_ID = '__test_bundle__'
 
@@ -37,4 +39,19 @@ export function makeFetchStub(frame, commitId = TEST_COMMIT_ID) {
         'content-type': 'application/octet-stream'
       }
     })
+}
+
+// Mirror etagPathFor(detectRuntime().cdsVersion) from searchMarkdownDocs.js using the
+// same createRequire + process.cwd() logic, so save/restore always targets the exact
+// path _downloadEmbeddings() writes — including the 'latest' fallback when no CAP
+// runtime is detected in the test working directory.
+export function getManifestEtagPath() {
+  try {
+    const req = createRequire(path.join(process.cwd(), 'package.json'))
+    const c = req('@sap/cds')
+    if (c.env?.['project-nature'] === 'nodejs') {
+      return path.join(DEFAULT_DIR, 'etags', c.version, 'manifest.etag')
+    }
+  } catch {}
+  return path.join(DEFAULT_DIR, 'etags', UNKNOWN_CDS_VERSION, 'manifest.etag')
 }

--- a/tests/helpers/testBundle.js
+++ b/tests/helpers/testBundle.js
@@ -52,6 +52,6 @@ export function getManifestEtagPath() {
     if (c.env?.['project-nature'] === 'nodejs') {
       return path.join(DEFAULT_DIR, 'etags', c.version, 'manifest.etag')
     }
-  } catch {}
+  } catch { /* not a cds node project */ }
   return path.join(DEFAULT_DIR, 'etags', UNKNOWN_CDS_VERSION, 'manifest.etag')
 }

--- a/tests/searchMarkdownDocs.test.js
+++ b/tests/searchMarkdownDocs.test.js
@@ -1,18 +1,40 @@
 import { fileURLToPath } from 'url'
-import { MODEL_FOLDER } from '../lib/calculateEmbeddings.js'
+import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR, MODEL_FOLDER } from '../lib/calculateEmbeddings.js'
 import path from 'path'
+import fs from 'fs/promises'
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert'
+import { buildTestBundle, makeFetchStub, TEST_COMMIT_ID } from './helpers/testBundle.js'
+import cds from '@sap/cds'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-import { test, describe } from 'node:test'
-import assert from 'node:assert'
-import fs from 'fs/promises'
-
 const embeddingsDir = path.join(__dirname, '..', 'embeddings', MODEL_FOLDER)
+const testBundleDir = path.join(embeddingsDir, TEST_COMMIT_ID)
+const manifestEtagPath = path.join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
 
-// Use dynamic import to ensure environment variable is set before module evaluation
+// Save etag that may exist before we overwrite it with the test bundle etag.
+const savedEtag = await fs.readFile(manifestEtagPath, 'utf-8').catch(() => null)
+
+// Build real embeddings and mock fetch BEFORE importing searchMarkdownDocs.js.
+// That module fires downloadEmbeddings() at module load time — mock must be in place first.
+const testFrame = await buildTestBundle()
+globalThis.fetch = makeFetchStub(testFrame)
+
 const searchModule = await import('../lib/searchMarkdownDocs.js')
 const searchMarkdownDocs = searchModule.default
 const { formatResult } = searchModule
+
+after(async () => {
+  globalThis.fetch = undefined
+  await fs.rm(testBundleDir, { recursive: true, force: true }).catch(() => {})
+  if (savedEtag !== null) {
+    await fs.mkdir(path.dirname(manifestEtagPath), { recursive: true })
+    await fs.writeFile(manifestEtagPath, savedEtag)
+  } else {
+    await fs.rm(path.dirname(manifestEtagPath), { recursive: true, force: true }).catch(() => {})
+  }
+})
 
 describe('formatResult', () => {
   test('returns content unchanged when meta is absent', () => {
@@ -53,21 +75,19 @@ describe('formatResult', () => {
 })
 
 describe('searchMarkdownDocs integration tests', () => {
-  test.skip('should download and load embeddings from server', async () => {
-    // This test verifies the full download and search functionality
+  test('should download and load embeddings from server', async () => {
     const result = await searchMarkdownDocs('entity definition', 3)
 
     assert(typeof result === 'string', 'Result should be a string')
     assert(result.length > 0, 'Result should not be empty')
     assert(result.includes('---'), 'Result should contain separators between chunks')
 
-    // Verify files were created
     const jsonExists = await fs
-      .access(path.join(embeddingsDir, 'code-chunks.json'))
+      .access(path.join(testBundleDir, 'code-chunks.json'))
       .then(() => true)
       .catch(() => false)
     const binExists = await fs
-      .access(path.join(embeddingsDir, 'code-chunks.bin'))
+      .access(path.join(testBundleDir, 'code-chunks.bin'))
       .then(() => true)
       .catch(() => false)
 
@@ -75,7 +95,7 @@ describe('searchMarkdownDocs integration tests', () => {
     assert(binExists, 'Binary embeddings file should exist after download')
   })
 
-  test.skip('should handle search queries and return relevant results', async () => {
+  test('should handle search queries and return relevant results', async () => {
     const queries = ['entity definition', 'service implementation', 'authentication', 'database schema']
 
     for (const query of queries) {
@@ -88,22 +108,19 @@ describe('searchMarkdownDocs integration tests', () => {
     }
   })
 
-  test.skip('should use embeddings files consistently', async () => {
-    // Get file stats before making calls
-    const jsonPath = path.join(embeddingsDir, 'code-chunks.json')
-    const binPath = path.join(embeddingsDir, 'code-chunks.bin')
+  test('should use embeddings files consistently', async () => {
+    const jsonPath = path.join(testBundleDir, 'code-chunks.json')
+    const binPath = path.join(testBundleDir, 'code-chunks.bin')
 
-    // Ensure files exist first
+    // Files already written by the initial download; this call just uses them.
     await searchMarkdownDocs('test', 1)
 
     const jsonStatBefore = await fs.stat(jsonPath)
     const binStatBefore = await fs.stat(binPath)
 
-    // Make several calls
     const result1 = await searchMarkdownDocs('entity', 1)
     const result2 = await searchMarkdownDocs('service', 1)
 
-    // Check that files weren't modified (using cached files)
     const jsonStatAfter = await fs.stat(jsonPath)
     const binStatAfter = await fs.stat(binPath)
 
@@ -112,7 +129,6 @@ describe('searchMarkdownDocs integration tests', () => {
     assert(result1.length > 0, 'First result should not be empty')
     assert(result2.length > 0, 'Second result should not be empty')
 
-    // Files should have same modification time (not re-downloaded)
     assert.strictEqual(
       jsonStatBefore.mtime.getTime(),
       jsonStatAfter.mtime.getTime(),
@@ -124,24 +140,22 @@ describe('searchMarkdownDocs integration tests', () => {
       'Binary file should not be re-downloaded'
     )
   })
-  test.skip('should reuse downloaded files on subsequent calls', async () => {
-    // First call - downloads embeddings
+
+  test('should reuse downloaded files on subsequent calls', async () => {
     const result1 = await searchMarkdownDocs('entity', 1)
 
-    // Verify files exist
     const jsonExists = await fs
-      .access(path.join(embeddingsDir, 'code-chunks.json'))
+      .access(path.join(testBundleDir, 'code-chunks.json'))
       .then(() => true)
       .catch(() => false)
     const binExists = await fs
-      .access(path.join(embeddingsDir, 'code-chunks.bin'))
+      .access(path.join(testBundleDir, 'code-chunks.bin'))
       .then(() => true)
       .catch(() => false)
 
     assert(jsonExists, 'JSON file should exist')
     assert(binExists, 'Binary file should exist')
 
-    // Second call - should use existing files
     const result2 = await searchMarkdownDocs('service', 1)
     assert(typeof result1 === 'string', 'First result should be a string')
     assert(typeof result2 === 'string', 'Second result should be a string')
@@ -149,15 +163,14 @@ describe('searchMarkdownDocs integration tests', () => {
     assert(result2.length > 0, 'Second result should not be empty')
   })
 
-  test.skip('should respect maxResults parameter', async () => {
+  test('should respect maxResults parameter', async () => {
     const maxResults = 5
     const result = await searchMarkdownDocs('entity service', maxResults)
 
     const chunks = result.split('\n---\n')
     assert(chunks.length <= maxResults, `Should return at most ${maxResults} chunks`)
 
-    // Test with different maxResults values
-    for (const max of [1, 3, 10]) {
+    for (const max of [1, 3, 6]) {
       const limitedResult = await searchMarkdownDocs('cds model', max)
       const limitedChunks = limitedResult.split('\n---\n')
       assert(limitedChunks.length <= max, `Should return at most ${max} chunks`)

--- a/tests/searchMarkdownDocs.test.js
+++ b/tests/searchMarkdownDocs.test.js
@@ -1,17 +1,16 @@
 import { fileURLToPath } from 'url'
-import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR, MODEL_FOLDER } from '../lib/calculateEmbeddings.js'
+import { MODEL_FOLDER } from '../lib/calculateEmbeddings.js'
 import path from 'path'
 import fs from 'fs/promises'
 import { test, describe, after } from 'node:test'
 import assert from 'node:assert'
-import { buildTestBundle, makeFetchStub, TEST_COMMIT_ID } from './helpers/testBundle.js'
-import cds from '@sap/cds'
+import { buildTestBundle, makeFetchStub, getManifestEtagPath, TEST_COMMIT_ID } from './helpers/testBundle.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const embeddingsDir = path.join(__dirname, '..', 'embeddings', MODEL_FOLDER)
 const testBundleDir = path.join(embeddingsDir, TEST_COMMIT_ID)
-const manifestEtagPath = path.join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
+const manifestEtagPath = getManifestEtagPath()
 
 // Save etag that may exist before we overwrite it with the test bundle etag.
 const savedEtag = await fs.readFile(manifestEtagPath, 'utf-8').catch(() => null)

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,18 +1,16 @@
 // Node.js test runner (test) for lib/tools.js
 import assert from 'node:assert'
-import { describe, test } from 'node:test'
+import { describe, test, after } from 'node:test'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import fs from 'fs/promises'
-import cds from '@sap/cds'
-import { after } from 'node:test'
-import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
-import { buildTestBundle, makeFetchStub, TEST_COMMIT_ID } from './helpers/testBundle.js'
+import { DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
+import { buildTestBundle, makeFetchStub, getManifestEtagPath, TEST_COMMIT_ID } from './helpers/testBundle.js'
 
 const sampleProjectPath = join(dirname(fileURLToPath(import.meta.url)), 'sample')
 
 const testBundleDir = join(DEFAULT_EMBEDDINGS_DIR, TEST_COMMIT_ID)
-const manifestEtagPath = join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
+const manifestEtagPath = getManifestEtagPath()
 const savedEtag = await fs.readFile(manifestEtagPath, 'utf-8').catch(() => null)
 
 // Build real embeddings and mock fetch BEFORE importing tools.js.

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,12 +1,37 @@
 // Node.js test runner (test) for lib/tools.js
-import tools from '../lib/tools.js'
 import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
+import fs from 'fs/promises'
+import cds from '@sap/cds'
+import { after } from 'node:test'
+import { DEFAULT_DIR, DEFAULT_EMBEDDINGS_DIR } from '../lib/calculateEmbeddings.js'
+import { buildTestBundle, makeFetchStub, TEST_COMMIT_ID } from './helpers/testBundle.js'
 
-// Point to the sample project directory
 const sampleProjectPath = join(dirname(fileURLToPath(import.meta.url)), 'sample')
+
+const testBundleDir = join(DEFAULT_EMBEDDINGS_DIR, TEST_COMMIT_ID)
+const manifestEtagPath = join(DEFAULT_DIR, 'etags', cds.version, 'manifest.etag')
+const savedEtag = await fs.readFile(manifestEtagPath, 'utf-8').catch(() => null)
+
+// Build real embeddings and mock fetch BEFORE importing tools.js.
+// tools.js statically imports searchMarkdownDocs.js which fires downloadEmbeddings() at module load.
+const testFrame = await buildTestBundle()
+globalThis.fetch = makeFetchStub(testFrame)
+
+const tools = (await import('../lib/tools.js')).default
+
+after(async () => {
+  globalThis.fetch = undefined
+  await fs.rm(testBundleDir, { recursive: true, force: true }).catch(() => {})
+  if (savedEtag !== null) {
+    await fs.mkdir(dirname(manifestEtagPath), { recursive: true })
+    await fs.writeFile(manifestEtagPath, savedEtag)
+  } else {
+    await fs.rm(dirname(manifestEtagPath), { recursive: true, force: true }).catch(() => {})
+  }
+})
 
 describe('tools', () => {
   test('search_model: should find services', async () => {
@@ -56,7 +81,6 @@ describe('tools', () => {
     assert(books.length > 0, 'Should find at least one entity')
     assert(books[0].name, 'AdminService.Books', 'Should find AdminService.Books entity')
 
-    // Check that keys are present and correct
     assert(books[0].elements.ID, 'Books entity should have key ID')
     assert(books[0].elements.ID.key === true, 'ID should be marked as key')
   })
@@ -70,7 +94,6 @@ describe('tools', () => {
     })
     assert(Array.isArray(books), 'Result should be an array')
     assert(books.length > 0, 'Should find at least one entity')
-    // Check draft fields
     assert(books[0].elements.IsActiveEntity, 'Draft-enabled entity should have IsActiveEntity')
     assert(books[0].elements.IsActiveEntity.key === true, 'IsActiveEntity should be marked as key')
     assert(books[0].elements.HasActiveEntity, 'Draft-enabled entity should have HasActiveEntity')
@@ -101,8 +124,7 @@ describe('tools', () => {
     assert(typeof services[0] === 'string', 'Should return only names')
   })
 
-  test.skip('search_docs: should find docs', async () => {
-    // Normal search
+  test('search_docs: should find docs', async () => {
     const results = await tools.search_docs.handler({
       query: 'how to create a new cap project',
       maxResults: 10
@@ -110,7 +132,7 @@ describe('tools', () => {
     assert(results.toLowerCase().includes('cds init'), 'Should contain the words cds init')
   })
 
-  test.skip('search_docs: event mesh should mention enterprise-messaging', async () => {
+  test('search_docs: event mesh should mention enterprise-messaging', async () => {
     const meshResults = await tools.search_docs.handler({
       query: 'event mesh config',
       maxResults: 10


### PR DESCRIPTION
# Enable Mocked Docs Resource Tests

### Tests

✅ Added deterministic mocking for the docs resources/embeddings endpoint so `search_docs`, download, offline, and related tool tests can run without relying on external network resources.

### Changes

* `tests/helpers/testBundle.js`: Added utilities to build a small real embeddings bundle with CAP-relevant test chunks and provide a reusable fetch stub with commit/version headers.
* `tests/helpers/mock-fetch.mjs`: Added a subprocess-compatible fetch mock loaded via `NODE_OPTIONS`, serving the generated test bundle for CLI tests.
* `tests/cli.test.js`: Re-enabled previously skipped `search_docs`, `--download`, and offline docs tests by injecting the mocked fetch endpoint and pre-seeding local embeddings for offline scenarios. Added setup/cleanup to preserve existing etag state.
* `tests/searchMarkdownDocs.test.js`: Re-enabled integration tests for downloading, searching, caching, result limits, and reuse of embeddings files using the mocked bundle. Added cleanup to remove generated test artifacts and restore etag state.
* `tests/tools.test.js`: Re-enabled `search_docs` tool tests by dynamically importing tools after installing the mocked fetch implementation, ensuring module-load downloads are intercepted reliably.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Event Trigger: `pull_request.opened`
- LLM: `gpt-5.5`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `f0394ce0-adbc-11f1-9b5c-c4815a9f4ddf`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
