### PR TITLE
fix: blank Cache-Control/Pragma so conditional GET can 304

### DIFF
--- a/lib/searchMarkdownDocs.js
+++ b/lib/searchMarkdownDocs.js
@@ -135,7 +135,11 @@ async function _downloadEmbeddings() {
   const { runtime, cdsVersion } = detectRuntime()
   const etagPath = etagPathFor(cdsVersion)
   const cached = await fs.readFile(etagPath, 'utf-8').then(JSON.parse).catch(() => null)
-  const headers = cached?.etag ? { 'If-None-Match': cached.etag.trim() } : {}
+  // Blank Cache-Control/Pragma: undici's fetch auto-adds `no-cache`, which
+  // trips Express `req.fresh` server-side and forces a 200 even when ETag matches.
+  const headers = cached?.etag
+    ? { 'If-None-Match': cached.etag.trim(), 'Cache-Control': '', Pragma: '' }
+    : {}
   const resp = await fetch(getBundleUrl(runtime, cdsVersion), { headers })
 
   if (resp.status === 304) {


### PR DESCRIPTION
Node's fetch (undici) auto-injects `Cache-Control: no-cache` and `Pragma: no-cache` on every request. Express `req.fresh` treats `Cache-Control: no-cache` as always-stale, so the server-side `getEmbeddings` handler never returns 304 even when the client's If-None-Match matches the current ETag — every startup re-downloads the full embeddings bundle.

Send empty values for both headers to suppress undici's defaults so conditional GET works end-to-end.